### PR TITLE
Update definitions for Spack 1.0

### DIFF
--- a/packages/cln/package.py
+++ b/packages/cln/package.py
@@ -5,8 +5,11 @@
 
 import os
 
-import spack.build_systems.autotools
-import spack.build_systems.cmake
+from spack_repo.builtin.build_systems import autotools
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems import cmake
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
 
 
@@ -55,12 +58,12 @@ class Cln(CMakePackage, AutotoolsPackage):
 
     depends_on("gmp@4.1:", when="+gmp", type=("build","link","run"))
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         return [self.define_from_variant("CLN_USE_GMP", "gmp")]
 
 
-class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def autoreconf(self, spec, prefix):
         autoreconf_args = ["-i"]
 

--- a/packages/libzip/package.py
+++ b/packages/libzip/package.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.build_systems.autotools
-import spack.build_systems.cmake
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems import cmake
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
 
 
@@ -81,7 +83,7 @@ class Libzip(CMakePackage, AutotoolsPackage):
         )
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         return [
             self.define_from_variant("ENABLE_GNUTLS", "gnutls"),

--- a/packages/metis/package.py
+++ b/packages/metis/package.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-import spack.build_systems.cmake
+from spack_repo.builtin.build_systems import cmake
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
 
 
@@ -51,7 +53,7 @@ class Metis(CMakePackage):
 
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         options = [
             self.define_from_variant("SHARED", "shared"),

--- a/packages/mmg/package.py
+++ b/packages/mmg/package.py
@@ -5,7 +5,9 @@
 
 import os
 
-import spack.build_systems.cmake
+from spack_repo.builtin.build_systems import cmake
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
 from spack.util.executable import which
 
@@ -56,7 +58,7 @@ class Mmg(CMakePackage):
     depends_on("vtk", when="+vtk")
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         shared_active = self.spec.satisfies("+shared")
         return [


### PR DESCRIPTION
Spack 1.0 changes where the imports are, in preparations for moving all of the packages to a new repository.

With these changes, the repository properly works for the develop branch of Spack.